### PR TITLE
Feat: Automated advancement rolls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 .vscode/
+# Ignore directories in packs to remove v11 dbs
+packs/*/

--- a/lang/en.json
+++ b/lang/en.json
@@ -30,7 +30,7 @@
             "profession": "Profession",
             "skill": "Skill",
             "spell": "Spell",
-            "weapon": "Weapon"                
+            "weapon": "Weapon"
         }
     },
     "DoD": {
@@ -62,7 +62,6 @@
             "banes": "Banes",
             "rating": "Armor Rating",
             "bonuses": "Bonus Armor"
-
         },
         "attackTypes": {
             "ranged": "Ranged attack",
@@ -221,7 +220,6 @@
             "pushChoiceLabel": "Choose condition:",
             "parryWeapon": "<p>If the parried damage exceeds your weapon's durability (<b>{durability}</b>), the weapon is damaged. Piercing damage can not damage a weapon.</p>",
             "parryShield": "<p>If the parried damage exceeds your shield's durability (<b>{durability}</b>), the shield is damaged. Piercing damage can not damage a shield.</p>"
-
         },
         "secondaryAttributeTypes": {
             "none": "-",
@@ -243,6 +241,7 @@
             "attributeTooltip": "The skill's Attribute",
             "hide": "Hide",
             "hideTooltip": "Hides skill from the list of Trained Skills",
+            "rollAdvancement": "Roll to advance skill at end of session",
             "type": "Type",
             "typeTooltip": "The skill's Type"
         },
@@ -250,7 +249,7 @@
             "core": "Core skill",
             "weapon": "Weapon skill",
             "secondary": "Secondary skill",
-            "magic": "School of magic"  
+            "magic": "School of magic"
         },
         "spell": {
             "areaOfEffect": "Area",
@@ -281,7 +280,7 @@
             "range": "Range",
             "cone": "Cone",
             "sphere": "Sphere"
-        },        
+        },
         "supplyTypes": {
             "common": "Common",
             "uncommon": "Uncommon",
@@ -347,8 +346,7 @@
             "topplingTooltip": "Gives advantage on Topple",
             "unarmed": "Unarmed",
             "unarmedTooltip": "Unarmed weapons don't count towards weapons at hand"
-            
-        },    
+        },
         "ui": {
             "character-sheet": {
                 "abilities": "Abilities",
@@ -417,7 +415,7 @@
                 "willPoints": "Willpower Points",
                 "wp": "WP"
             },
-            "chat":{
+            "chat": {
                 "damageApplied": "<b>{damage} damage</b> applied to <b>{actor}</b>.",
                 "damageAppliedDetails": "{damage} damage vs {armor} armor rating.",
                 "damageAppliedMultiplier": "x{multiplier} multiplier.",
@@ -461,7 +459,6 @@
                 "useAbilityWithoutWP": "Use <b>{ability}</b>?",
                 "weaponFeatures": "Weapon Features"
             }
-
         },
         "INFO": {
             "professionSkillAdded": "Added Profession Skill: {skill}"
@@ -493,6 +490,6 @@
             "noRangedMishapTable": "Missing the misphap table for ranged weapons.",
             "noMagicMishapTable": "Missing the magic misphap table.",
             "maxWeaponsEquipped": "Maximum 3 equipped weapons."
-      }
+        }
     }
 }

--- a/modules/character-sheet.js
+++ b/modules/character-sheet.js
@@ -1,20 +1,20 @@
-import DoD_Utility from "./utility.js";
+import * as DoDChat from "./chat.js";
+import { DoD } from "./config.js";
 import DoDAttributeTest from "./tests/attribute-test.js";
 import DoDSkillTest from "./tests/skill-test.js";
 import DoDSpellTest from "./tests/spell-test.js";
 import DoDWeaponTest from "./tests/weapon-test.js";
-import { DoD } from "./config.js";
-import * as DoDChat from "./chat.js";
+import DoD_Utility from "./utility.js";
 
 export default class DoDCharacterSheet extends ActorSheet {
-    
+
     static get defaultOptions() {
         return mergeObject(super.defaultOptions,  {
             width: 700,
             height: 775,
             classes: ["DoD", "sheet", "character"],
-            dragDrop: [{ 
-                dragSelector: ".item-list .item", 
+            dragDrop: [{
+                dragSelector: ".item-list .item",
                 dropSelector: null,
                 permissions: { dragstart: () => true }
             }],
@@ -52,8 +52,8 @@ export default class DoDCharacterSheet extends ActorSheet {
         document.removeEventListener('keydown', this.keydownListener);
         Hooks.off("dropActorSheetData", this.onDropTableListener);
         return super.close(options);
-     }   
-  
+     }
+
      render(force, options) {
         this.keydownListener = this.#onKeydown.bind(this);
         document.addEventListener('keydown', this.keydownListener);
@@ -71,19 +71,19 @@ export default class DoDCharacterSheet extends ActorSheet {
                 return;
             }
             event.preventDefault();
-            event.stopImmediatePropagation();            
+            event.stopImmediatePropagation();
             const itemId = this.#focusElement.dataset.itemId;
             const item = this.actor.items.get(itemId);
 
             this.#focusElement = null;
 
             if (item.type === "skill") {
-                return item.update({ ["system.value"]: 0}); 
+                return item.update({ ["system.value"]: 0});
             } else {
                 return this.actor.deleteEmbeddedDocuments("Item", [itemId]);
             }
         }
-     }    
+     }
 
     async getData() {
         const baseData = super.getData();
@@ -102,7 +102,7 @@ export default class DoDCharacterSheet extends ActorSheet {
                 return await TextEditor.enrichHTML(html, {
                     secrets: sheetData.actor.isOwner,
                     async: true
-                });    
+                });
             } else {
                 return html;
             }
@@ -133,7 +133,7 @@ export default class DoDCharacterSheet extends ActorSheet {
         let equippedHelmet = sheetData.actor.system.equippedHelmet;
         let memento = null;
         let smallItems = [];
-        
+
         for (let item of sheetData.actor.items.contents) {
 
             // any item can be a memento
@@ -143,7 +143,7 @@ export default class DoDCharacterSheet extends ActorSheet {
                     continue;
                 } else {
                     // Memento slot busy. Clear flag and process as normal item
-                    item.update({ ["system.memento"]: false}); 
+                    item.update({ ["system.memento"]: false});
                 }
             }
 
@@ -170,14 +170,14 @@ export default class DoDCharacterSheet extends ActorSheet {
                 let spell = item;
 
                 spells.push(spell);
-                
+
                 if (!schools[spell.system.school]) {
                     schools[spell.system.school] = [];
                 }
                 schools[spell.system.school].push(spell);
                 continue;
             }
-            
+
             if (item.type == "weapon") {
                 if (item.system.worn) {
                     // TODO limit 3
@@ -191,13 +191,13 @@ export default class DoDCharacterSheet extends ActorSheet {
                         memento = item;
                     } else {
                         // Memento slot busy. Clear flag and process as normal item
-                        item.update({ ["system.memento"]: false}); 
+                        item.update({ ["system.memento"]: false});
                     }
                 }
 
                 continue;
             }
-            
+
             if (item.type == "armor") {
                 if (!item.system.worn) {
                     inventory.push(item);
@@ -211,7 +211,7 @@ export default class DoDCharacterSheet extends ActorSheet {
                 }
                 continue;
             }
-            
+
             if (item.type == "item") {
                 if (item.system.weight == 0 && item.system.type != "backpack" && this.actor.type == "character")
                 {
@@ -222,7 +222,7 @@ export default class DoDCharacterSheet extends ActorSheet {
                 continue;
             }
         }
-        
+
         // Kin and Profession
         sheetData.kin = sheetData.actor.system.kin;
         sheetData.kinName = sheetData.kin?.name;
@@ -231,8 +231,8 @@ export default class DoDCharacterSheet extends ActorSheet {
 
         // Items (skills, abilities, spells)
         sheetData.coreSkills = sheetData.actor.system.coreSkills?.sort(DoD_Utility.nameSorter);;
-        sheetData.magicSkills = sheetData.actor.system.magicSkills?.sort(DoD_Utility.nameSorter); 
-        sheetData.secondarySkills = sheetData.actor.system.secondarySkills?.sort(DoD_Utility.nameSorter); 
+        sheetData.magicSkills = sheetData.actor.system.magicSkills?.sort(DoD_Utility.nameSorter);
+        sheetData.secondarySkills = sheetData.actor.system.secondarySkills?.sort(DoD_Utility.nameSorter);
         sheetData.weaponSkills = sheetData.actor.system.weaponSkills?.sort(DoD_Utility.nameSorter);
         sheetData.trainedSkills = sheetData.actor.system.trainedSkills?.sort(DoD_Utility.nameSorter).filter(s => s.system.hideTrained == false);
 
@@ -241,7 +241,7 @@ export default class DoDCharacterSheet extends ActorSheet {
         sheetData.professionAbilities = professionAbilities.sort(DoD_Utility.nameSorter);
         sheetData.abilities = heroicAbilities.concat(kinAbilities, professionAbilities).sort(DoD_Utility.nameSorter);
 
-        // 
+        //
         let formattedAbilities = [];
         for (let i=0, j; i < sheetData.abilities.length; i=j) {
             let count = 1;
@@ -255,7 +255,7 @@ export default class DoDCharacterSheet extends ActorSheet {
             }
             // Push first unique ability. Add ability count in parenthesis (if multiple)
             formattedAbilities.push({
-                id: sheetData.abilities[i].id, 
+                id: sheetData.abilities[i].id,
                 name: count == 1 ? sheetData.abilities[i].name : sheetData.abilities[i].name + " (" + count + ")"
             });
         }
@@ -303,7 +303,7 @@ export default class DoDCharacterSheet extends ActorSheet {
                 sheetData.largeWP = sheetData.maxWP > 40; // switch to large wp widget
             }
         }
-    }  
+    }
 
     _updateEncumbrance(sheetData) {
         if (this.actor.type == "character") {
@@ -317,7 +317,7 @@ export default class DoDCharacterSheet extends ActorSheet {
             }
             let coins = sheetData.actor.system.currency.gc + sheetData.actor.system.currency.sc + sheetData.actor.system.currency.cc;
             sheetData.encumbrance += Math.floor(coins/100);
-            
+
             sheetData.overEncumbered = sheetData.encumbrance > sheetData.maxEncumbrance;
         }
     }
@@ -344,6 +344,7 @@ export default class DoDCharacterSheet extends ActorSheet {
             html.find(".rollable-skill").on("click contextmenu", this._onSkillRoll.bind(this));
             html.find(".rollable-damage").on("click contextmenu", this._onDamageRoll.bind(this));
             html.find(".use-item").on("click contextmenu", this._onUseItem.bind(this));
+            html.find("[data-action='roll-advancement']").click(this._onAdvancementRoll.bind(this))
 
             html.find(".hit-points-max-label").change(this._onEditHp.bind(this));
             html.find(".hit-points-current-label").change(this._onEditCurrentHp.bind(this));
@@ -358,15 +359,15 @@ export default class DoDCharacterSheet extends ActorSheet {
             html.find(".death-rolls-failure").on("click contextmenu", this._onDeathRollsFailureClick.bind(this));
             html.find(".death-rolls-failure-label").on("click contextmenu", this._onDeathRollsFailureClick.bind(this));
 
-            html.find(".rest-round").on("click", this._onRestRound.bind(this));                
-            html.find(".rest-stretch").on("click", this._onRestStretch.bind(this));                
-            html.find(".rest-shift").on("click", this._onRestShift.bind(this));                
+            html.find(".rest-round").on("click", this._onRestRound.bind(this));
+            html.find(".rest-stretch").on("click", this._onRestStretch.bind(this));
+            html.find(".rest-shift").on("click", this._onRestShift.bind(this));
 
             html.find(".item-create").click(this._onItemCreate.bind(this));
 
             if (this.object.type === "monster") {
-                html.find(".monster-attack").on("click contextmenu", this._onMonsterAttack.bind(this));                
-                html.find(".monster-defend").on("click", this._onMonsterDefend.bind(this));                
+                html.find(".monster-attack").on("click contextmenu", this._onMonsterAttack.bind(this));
+                html.find(".monster-defend").on("click", this._onMonsterDefend.bind(this));
             }
         } else if (this.object.isObserver) {
             // Enable right-clicking skills & items
@@ -389,7 +390,7 @@ export default class DoDCharacterSheet extends ActorSheet {
         event.preventDefault();
         event.currentTarget?.blur();
 
-        const table = this.actor.system.attackTable ? fromUuidSync(this.actor.system.attackTable) : null; 
+        const table = this.actor.system.attackTable ? fromUuidSync(this.actor.system.attackTable) : null;
         if (!table) {
             DoD_Utility.WARNING("DoD.WARNING.missingMonsterAttackTable");
             return;
@@ -400,7 +401,7 @@ export default class DoDCharacterSheet extends ActorSheet {
             return DoD_Utility.monsterAttack(this.actor, table);
         } else { // right click
             return table.sheet.render(true);
-        }        
+        }
     }
 
     async _onMonsterDefend(event) {
@@ -419,8 +420,8 @@ export default class DoDCharacterSheet extends ActorSheet {
 
     _onHitPointClick(event) {
         event.preventDefault();
-  
-        let hp = this.actor.system.hitPoints; 
+
+        let hp = this.actor.system.hitPoints;
         if (event.type == "click") { // left click
             if (hp.value > 0) {
                 return this.actor.update({ ["system.hitPoints.value"]: hp.value-1});
@@ -435,7 +436,7 @@ export default class DoDCharacterSheet extends ActorSheet {
     _onWillPointClick(event) {
         event.preventDefault();
 
-        let wp = this.actor.system.willPoints; 
+        let wp = this.actor.system.willPoints;
         if (event.type == "click") { // left click
             if (wp.value > 0) {
                 return this.actor.update({ ["system.willPoints.value"]: wp.value-1});
@@ -450,8 +451,8 @@ export default class DoDCharacterSheet extends ActorSheet {
     async _onDeathRollsSuccessClick(event) {
         event.preventDefault();
 
-        let successes = this.actor.system.deathRolls.successes; 
-        console.assert(successes >= 0 && successes <= 3, "Dragonbane: system.deathRolls.successes out of range for " + this.actor.uuid); 
+        let successes = this.actor.system.deathRolls.successes;
+        console.assert(successes >= 0 && successes <= 3, "Dragonbane: system.deathRolls.successes out of range for " + this.actor.uuid);
         if (event.type == "click") { // left click
             if (successes < 3) {
                 return await this.actor.update({ ["system.deathRolls.successes"]: successes+1});
@@ -467,7 +468,7 @@ export default class DoDCharacterSheet extends ActorSheet {
         event.preventDefault();
 
         let failures = this.actor.system.deathRolls.failures;
-        console.assert(failures >= 0 && failures <= 3, "Dragonbane: system.deathRolls.failures out of range for " + this.actor.uuid); 
+        console.assert(failures >= 0 && failures <= 3, "Dragonbane: system.deathRolls.failures out of range for " + this.actor.uuid);
         if (event.type == "click") { // left click
             if (failures < 3) {
                 return await this.actor.update({ ["system.deathRolls.failures"]: failures+1});
@@ -487,7 +488,7 @@ export default class DoDCharacterSheet extends ActorSheet {
         const currentWP = this.actor.system.willPoints.value;
         const maxWP = this.actor.system.willPoints.max;
         const newWP = Math.min(maxWP, currentWP + roll.total);
-        
+
         const msg = await roll.toMessage({
             user: game.user.id,
             actor: this.actor,
@@ -507,7 +508,7 @@ export default class DoDCharacterSheet extends ActorSheet {
 
         // Make roll
         const roll = await new Roll("D6[Hit Points] + D6[Willpower Points]").roll({async: true});
-       
+
         if (game.dice3d) {
             // Red for HP
             roll.dice[0].options.appearance = {
@@ -524,17 +525,17 @@ export default class DoDCharacterSheet extends ActorSheet {
                 edge: '#00a000',
             };
         }
-        
+
         // Calc HP
         const currentHP = this.actor.system.hitPoints.value;
         const maxHP = this.actor.system.hitPoints.max;
         const newHP = Math.min(maxHP, currentHP + Number(roll.terms[0].total));
-        
+
         // Calc WP
         const currentWP = this.actor.system.willPoints.value;
         const maxWP = this.actor.system.willPoints.max;
         const newWP = Math.min(maxWP, currentWP + Number(roll.terms[2].total));
-        
+
         // Render message
         const context =  {
             formula: roll.formula,
@@ -562,7 +563,7 @@ export default class DoDCharacterSheet extends ActorSheet {
             await this.actor.update({
                 ["system.hitPoints.value"]: newHP,
                 ["system.willPoints.value"]: newWP
-            });            
+            });
         }
 
     }
@@ -573,12 +574,12 @@ export default class DoDCharacterSheet extends ActorSheet {
 
         // Make roll
         const roll = await new Roll("D6[Hit Points] + D6[Willpower Points]").roll({async: true});
-        
+
         // Calc HP
         const currentHP = this.actor.system.hitPoints.value;
         const maxHP = this.actor.system.hitPoints.max;
         const newHP = maxHP;
-        
+
         // Calc WP
         const currentWP = this.actor.system.willPoints.value;
         const maxWP = this.actor.system.willPoints.max;
@@ -587,7 +588,7 @@ export default class DoDCharacterSheet extends ActorSheet {
         ChatMessage.create({
             user: game.user.id,
             flavor: game.i18n.format("DoD.ui.character-sheet.restShift", {actor: this.actor.name, hp: newHP - currentHP, wp: newWP - currentWP})
-        });        
+        });
         this.actor.update({
             ["system.hitPoints.value"]: newHP,
             ["system.willPoints.value"]: newWP,
@@ -656,7 +657,7 @@ export default class DoDCharacterSheet extends ActorSheet {
                 if (twoHanded) {
                     return item.update({["system.mainHand"]: element.checked, "system.offHand": element.checked});
                 }
-            }            
+            }
             return item.update({ [field]: element.checked });
         }
 
@@ -669,7 +670,7 @@ export default class DoDCharacterSheet extends ActorSheet {
 
         const newMax = Math.max(1, Math.floor(event.currentTarget.value));
         const currentDamage = Math.max(0, this.actor.system.hitPoints.max - this.actor.system.hitPoints.value);
-        const newValue = Math.max(0, newMax - currentDamage);        
+        const newValue = Math.max(0, newMax - currentDamage);
 
         return this.actor.update({
             ["system.hitPoints.max"]: newMax,
@@ -693,12 +694,12 @@ export default class DoDCharacterSheet extends ActorSheet {
 
         const newMax = Math.max(0, Math.floor(event.currentTarget.value));
         const currentDamage = Math.max(0, this.actor.system.willPoints.max - this.actor.system.willPoints.value);
-        const newValue = Math.max(0, newMax - currentDamage);       
-        
+        const newValue = Math.max(0, newMax - currentDamage);
+
         return this.actor.update({
             ["system.willPoints.max"]: newMax,
             ["system.willPoints.value"]: newValue
-        });        
+        });
     }
     _onEditCurrentWp(event) {
         event.preventDefault();
@@ -753,7 +754,7 @@ export default class DoDCharacterSheet extends ActorSheet {
     async _onAgeEdit(event) {
         event.preventDefault();
         event.currentTarget.blur();
-        
+
         const modifiers = {
             young: {
                 ["system.attributes.str.value"]: 0,
@@ -796,7 +797,7 @@ export default class DoDCharacterSheet extends ActorSheet {
     }
 
     _onItemDelete(event) {
-        event.preventDefault();       
+        event.preventDefault();
         let element = event.currentTarget;
         let itemId = element.closest(".sheet-table-data").dataset.itemId;
 
@@ -823,7 +824,7 @@ export default class DoDCharacterSheet extends ActorSheet {
         }
     }
 
- 
+
     async _onSkillRoll(event) {
         event.preventDefault();
 
@@ -877,7 +878,7 @@ export default class DoDCharacterSheet extends ActorSheet {
                                 ok: {
                                     icon: '<i class="fas fa-check"></i>',
                                     label: game.i18n.localize("DoD.ui.dialog.labelOk"),
-                                    callback: () => resolve(true)              
+                                    callback: () => resolve(true)
                                 },
                                 cancel: {
                                     icon: '<i class="fas fa-times"></i>',
@@ -934,7 +935,7 @@ export default class DoDCharacterSheet extends ActorSheet {
             const attribute = skill?.system.attribute;
             const damageBonus = this.actor.getDamageBonus(attribute);
             const damage = damageBonus ? weaponDamage + "+" + damageBonus : weaponDamage;
-            let damageType = DoD.damageTypes.none; 
+            let damageType = DoD.damageTypes.none;
 
             if (weapon.hasWeaponFeature("bludgeoning")) {
                 damageType = DoD.damageTypes.bludgeoning;
@@ -955,10 +956,10 @@ export default class DoDCharacterSheet extends ActorSheet {
             if (targets.length > 0) {
                 for (const target of targets) {
                     damageData.target = target.actor;
-                    await DoDChat.inflictDamageMessage(damageData);    
+                    await DoDChat.inflictDamageMessage(damageData);
                 }
             } else {
-                await DoDChat.inflictDamageMessage(damageData);    
+                await DoDChat.inflictDamageMessage(damageData);
             }
         } else { // right click - edit item
             weapon.sheet.render(true);
@@ -978,6 +979,21 @@ export default class DoDCharacterSheet extends ActorSheet {
         let attributeName = event.currentTarget.dataset.attribute;
         let test = new DoDAttributeTest(this.actor, attributeName, options);
         await test.roll();
+    }
+
+    async _onAdvancementRoll(event) {
+        const itemId = event.currentTarget.closest("tr").dataset.itemId;
+        const skillItem = this.actor.items.get(itemId);
+
+        const test = new DoDSkillTest(this.actor, skillItem)
+
+        const { postRollData } = await test.roll();
+        if (!postRollData) return;
+
+        const success = postRollData.success;
+        if (!success) await skillItem.update({ "system.value": skillItem.system.value + 1 });
+
+        await skillItem.update({ "system.advance": false })
     }
 
     _onConditionClick(event) {
@@ -1062,7 +1078,7 @@ export default class DoDCharacterSheet extends ActorSheet {
         if (itemData.type == "profession") {
             await this.actor.removeProfession();
         }
-        
+
         // If there are available slots, equip weapons, armor and helmet
         if (item.type == "weapon" || item.type == "armor" || item.type == "helmet") {
             itemData.system.worn =
@@ -1116,6 +1132,6 @@ export default class DoDCharacterSheet extends ActorSheet {
         }
 
         return this.actor.createEmbeddedDocuments("Item", [itemData]);
-    }    
+    }
 }
 

--- a/modules/tests/dod-test.js
+++ b/modules/tests/dod-test.js
@@ -7,7 +7,7 @@ export default class DoDTest {
         this.options = options;
         this.dialogData = {};
         this.preRollData = {};
-        this.postRollData = {};        
+        this.postRollData = {};
         this.noBanesBoons = options?.noBanesBoons;
         this.defaultBanesBoons = options?.defaultBanesBoons;
         this.skipDialog = options?.skipDialog || this.noBanesBoons || this.defaultBanesBoons;
@@ -21,7 +21,7 @@ export default class DoDTest {
         this.updatePreRollData();
         const formula = this.options.formula ?? this.formatRollFormula(this.preRollData);
         this.roll = await new Roll(formula).roll({async: true});
-        
+
         this.updatePostRollData();
         const messageData = this.formatRollMessage(this.postRollData);
         const messageTemplate = this.getMessageTemplate();
@@ -35,6 +35,7 @@ export default class DoDTest {
             }
         }
         this.roll.toMessage(messageData);
+        return this;
     }
 
     // This method should be overridden to provide title and label
@@ -62,13 +63,13 @@ export default class DoDTest {
             if (condition) {
                 if (!condition.value){
 
-                    this.postRollData.pushRollChoices[attribute] = 
+                    this.postRollData.pushRollChoices[attribute] =
                         game.i18n.localize("DoD.conditions." + attribute) + " (" +
                         game.i18n.localize("DoD.attributes." + attribute) + ")<br>";
                     if (!this.postRollData.pushRollChoice) {
                         this.postRollData.pushRollChoice = attribute;
                     }
-                }    
+                }
             } else {
                 DoD_Utility.ERROR("Missing condition for attribute " + attribute);
             }
@@ -100,21 +101,21 @@ export default class DoDTest {
                 let itemBanes = DoD_Utility.splitAndTrimString(item.system.banes.toLowerCase());
                 if (itemBanes.find(element => element.toLowerCase() == rollTarget)) {
                     let value = item.system.worn ? true : false;
-                    banes.push( {source: item.name, value: value});    
+                    banes.push( {source: item.name, value: value});
                 }
             }
             if (item.system.boons?.length) {
                 let itemBoons = DoD_Utility.splitAndTrimString(item.system.boons.toLowerCase());
                 if (itemBoons.find(element => element.toLowerCase() == rollTarget)) {
                     let value = item.system.worn ? true : false;
-                    boons.push( {source: item.name, value: value});    
+                    boons.push( {source: item.name, value: value});
                 }
             }
         }
 
         this.dialogData.banes = banes;
         this.dialogData.boons = boons;
-        
+
         // Needed for dialog box layout
         this.dialogData.fillerBanes = Math.max(0, boons.length - banes.length);
         this.dialogData.fillerBoons = Math.max(0, banes.length - boons.length);

--- a/modules/tests/skill-test.js
+++ b/modules/tests/skill-test.js
@@ -1,7 +1,7 @@
 import DoDTest from "./dod-test.js";
 
 
-export default class DoDSkillTest extends DoDTest  {
+export default class DoDSkillTest extends DoDTest {
 
     constructor(actor, skill, options) {
         super(actor, options);
@@ -11,7 +11,7 @@ export default class DoDSkillTest extends DoDTest  {
         this.canPush = options ? options.canPush != false : true;
         this.isReRoll = options?.isReRoll | false;
     }
-   
+
     async getRollOptions() {
         const label = game.i18n.localize("DoD.ui.dialog.skillRollLabel");
         const title = game.i18n.localize("DoD.ui.dialog.skillRollTitle") + ": " + this.skill.name;
@@ -41,12 +41,21 @@ export default class DoDSkillTest extends DoDTest  {
         if (this.options.targets) {
             this.postRollData.targetActor = this.options.targets[0].actor;
         }
+
+        if (this.postRollData.isDemon || this.postRollData.isDragon) {
+            this.setAdvancementMark();
+        }
+    }
+
+    async setAdvancementMark() {
+        if (this.skill.system.advance) return;
+        await this.skill.update({ "system.advance": true })
     }
 
     formatRollMessage(postRollData) {
         const target = postRollData.skill.system.value;
         const resultMsg = this.formatRollResult(postRollData);
-        const label = game.i18n.format(game.i18n.localize("DoD.roll.skillRoll"), {skill: postRollData.skill.name, result: resultMsg});
+        const label = game.i18n.format(game.i18n.localize("DoD.roll.skillRoll"), { skill: postRollData.skill.name, result: resultMsg });
         return {
             user: game.user.id,
             speaker: ChatMessage.getSpeaker({ actor: postRollData.actor }),

--- a/templates/partials/character-sheet-skills.hbs
+++ b/templates/partials/character-sheet-skills.hbs
@@ -19,7 +19,11 @@
                 {{#each coreSkills as |skill skillId|}}
                 <tr class="sheet-table-data item" data-item-id="{{skill.id}}">
                     <td class="checkbox-data">
-                        <input class="inline-edit" data-field="system.advance" type="checkbox" {{checked skill.system.advance}} />
+                        {{#if skill.system.advance}}
+                            <button type="button" data-action="roll-advancement"  title="{{localize "DoD.skill.rollAdvancement"}}"><i class="fas fa-arrow-up"></i></button>
+                        {{else}}
+                            <input class="inline-edit" data-field="system.advance" type="checkbox" {{checked skill.system.advance}} />
+                        {{/if}}
                     </td>
                     <td class="number-data narrow">
                         <input class="inline-edit" data-field="system.value" type="text" value="{{skill.system.value}}" data-dtype="Number"/>
@@ -34,16 +38,16 @@
                     <td class="icon-data">
                         <a class="item-delete" data-type="skill">
                             <i class="fas fa-trash"></i>
-                        </a>    
+                        </a>
                         <a class="item-edit" data-type="skill">
                             <i class="fas fa-edit"></i>
-                        </a>                                                
+                        </a>
                     </td>
                 </tr>
                 {{/each}}
             </table>
         </div>
-        
+
         <div>
             {{!-- Weapon Skills --}}
             <table class="sheet-table weapon-skills item-list">
@@ -78,10 +82,10 @@
                     <td class="icon-data">
                         <a class="item-delete" data-type="skill">
                             <i class="fas fa-trash"></i>
-                        </a>    
+                        </a>
                         <a class="item-edit" data-type="skill">
                             <i class="fas fa-edit"></i>
-                        </a>            
+                        </a>
                     </td>
                 </tr>
                 {{/each}}
@@ -119,10 +123,10 @@
                     <td class="icon-data">
                         <a class="item-delete" data-type="skill">
                             <i class="fas fa-trash"></i>
-                        </a>    
+                        </a>
                         <a class="item-edit" data-type="skill">
                             <i class="fas fa-edit"></i>
-                        </a>            
+                        </a>
                     </td>
                 </tr>
                 {{/each}}


### PR DESCRIPTION
# Automatic Skill Advancement Handling

Automation surrounding skill advancements is limited to automatically checking the "Advance" tickbox when a Dragon or Demon is rolled. A button next to each skill in the "Skill"-section of the character sheet now allows for rolling the relevant skill and will update the skill if the roll failed.

## Process
- chore: Add V11 db pack folders to gitignore
- feat: Automate adding skill marks
- feat: Automatically handle skill increases on failed roll
