### PR TITLE
Ci: Add CI pipeline for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+jobs:
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: "*"
+      - name: Install Dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Create Zipped Artifact
+        run: zip -r dragonbane.zip ./ -x ".git/*" ".gitignore" ".vscode/*" "gulpfile.js" "less/*" "node_modules/*" "package.json" "package-lock.json"
+      - name: Create Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "CHANGES.md, module.json, dragonbane.zip"
+          generateReleaseNotes: true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 var gulp = require('gulp');
 var less = require('gulp-less');
 
-gulp.task('less', function(cb) {
+gulp.task('less', function (cb) {
     gulp
         .src('less/dragonbane.less')
         .pipe(less())
@@ -11,8 +11,10 @@ gulp.task('less', function(cb) {
 
 gulp.task(
     'default',
-    gulp.series('less', function(cb) {
+    gulp.series('less', function (cb) {
         gulp.watch('less/*.less', gulp.series('less'));
         cb();
     })
 );
+
+gulp.task('build', gulp.series('less'));

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "build": "gulp build"
+  },
   "dependencies": {
     "gulp": "^4.0.2",
     "gulp-less": "^5.0.0"

--- a/system.json
+++ b/system.json
@@ -36,7 +36,7 @@
         "lang": "pt-BR",
         "name": "Português Brasileiro",
         "path": "lang/pt-br.json"
-      }      
+      }
     ],
     "packs": [
         {
@@ -57,6 +57,6 @@
     "secondaryTokenAttribute": "willPoints",
     "background": "systems/dragonbane/art/dragonbane-splash.webp",
     "url": "https://github.com/pafvel/dragonbane",
-    "manifest": "https://github.com/pafvel/dragonbane/releases/download/v1.1.0/system.json",
+    "manifest": "https://github.com/pafvel/dragonbane/releases/latest/download/system.json",
     "download": "https://github.com/pafvel/dragonbane/releases/download/v1.1.0/dragonbane.zip"
   }


### PR DESCRIPTION
Adds a workflow and gulp build (not watch) script for less, as well as corrects the download location of the manifest.