### PR TITLE
Prevent Advancement Marks from advancing skill beyond 18.

### DIFF
--- a/modules/character-sheet.js
+++ b/modules/character-sheet.js
@@ -1121,7 +1121,7 @@ export default class DoDCharacterSheet extends ActorSheet {
 
             // Make roll
             const roll = await new Roll("D20").roll({async: true});
-            const advance = roll.result > skillItem.system.value;
+            const advance = Math.min(DoD.skillMaximum , roll.result) > skillItem.system.value;
             const flavorText = advance ? 
                 game.i18n.format("DoD.skill.advancementSuccess", {skill: skillItem.name, old: skillItem.system.value, new: skillItem.system.value + 1}) :
                 game.i18n.format("DoD.skill.advancementFail", {skill: skillItem.name});

--- a/modules/config.js
+++ b/modules/config.js
@@ -83,6 +83,8 @@ DoD.skillTypes = {
     magic: "DoD.skillTypes.magic"
 };
 
+DoD.skillMaximum = 18;
+
 DoD.spellDurationTypes = {
     instant: "DoD.spellDurationTypes.instant",
     round: "DoD.spellDurationTypes.round",


### PR DESCRIPTION
Update to prevent the system from using an advancement mark to go beyond 18 - made it part of the config, so that someone could use worldscript to amend it, if they want it to be able to go above 18.