### PR TITLE
No need to make HP/WP roll on shift rest

### DIFF
--- a/modules/character-sheet.js
+++ b/modules/character-sheet.js
@@ -698,9 +698,6 @@ export default class DoDCharacterSheet extends ActorSheet {
             ["system.canRestStretch"]: true
         });   
 
-        // Make roll
-        const roll = await new Roll("D6[Hit Points] + D6[Willpower Points]").roll({async: true});
-
         // Calc HP
         const currentHP = this.actor.system.hitPoints.value;
         const maxHP = this.actor.system.hitPoints.max;


### PR DESCRIPTION
Characters heal fully, and the roll result isn't used. Just caused a little bit of confusion for my players.