### PR TITLE
Add manualBanes/manualBoons to test rolls

### DIFF
--- a/modules/macro.js
+++ b/modules/macro.js
@@ -34,6 +34,14 @@ export async function createItemMacro(data, slot) {
     }
 }
 
+/**
+ * Roll an attribute test
+ * @param {Actor} actor - Actor performing the test
+ * @param {('STR'|'CON'|'AGL'|'INT'|'WIL'|'CHA')} attributeName - Attribute being tested ('STR', 'CON', 'AGL', 'INT', 'WIL', 'CHA')
+ * @param {Object} [options] - options for the test
+ * @param {number} [options.manualBanes] - Number of manual (set outside the system) banes to apply
+ * @param {number] [options.manualBoons] - Number of manual (set outside the system) boons to apply
+ */
 export async function rollAttributeMacro(actor, attributeName, options = {}) {
 
     if (!actor || !(actor instanceof DoDActor)) {
@@ -41,7 +49,7 @@ export async function rollAttributeMacro(actor, attributeName, options = {}) {
         return;
     }
     
-    let test = new DoDAttributeTest(actor, attributeName, { defaultBanesBoons: true });
+    let test = new DoDAttributeTest(actor, attributeName, { defaultBanesBoons: true, ...options });
     await test.roll();
 }
 

--- a/modules/tests/dod-test.js
+++ b/modules/tests/dod-test.js
@@ -1,8 +1,16 @@
 import DoD_Utility from "../utility.js";
 import DoDRoll from "../roll.js";
 
+/** A Dragonbane test roll */
 export default class DoDTest {
 
+    /**
+     * Create a Test
+     * @param {Actor} actor - Actor performing the test
+     * @param {Object} [options] - Options for the test
+     * @param {number} [options.manualBanes] - Number of manual (set outside the system) banes to apply
+     * @param {number] [options.manualBoons] - Number of manual (set outside the system) boons to apply
+     */
     constructor(actor, options = {}) {
         this.actor = actor;
         this.options = options;
@@ -13,6 +21,10 @@ export default class DoDTest {
         this.defaultBanesBoons = options?.defaultBanesBoons;
         this.skipDialog = options?.skipDialog || this.noBanesBoons || this.defaultBanesBoons;
         this.autoSuccess = options?.autoSuccess;
+
+        // support manually passed banes/boons
+        this.manualBanes = options?.manualBanes;
+        this.manualBoons = options?.manualBoons;
     }
 
     async roll() {
@@ -123,6 +135,15 @@ export default class DoDTest {
                     boons.push( {source: item.name, value: value});
                 }
             }
+        }
+
+        // Maybe shorten these to "Manual (x<number>)" in the future
+        if (this.manualBanes) {
+            for(let i = 0; i < this.manualBanes; i++) { banes.push({ source: 'Manual', value: true }); }
+        }
+
+        if (this.manualBoons) {
+            for(let i = 0; i < this.manualBoons; i++) { boons.push({ source: 'Manual', value: true }); }
         }
 
         this.dialogData.banes = banes;


### PR DESCRIPTION
Add an option to manually specify additional banes/boons to a test roll (via `manualBanes` and `manualBoons`).

The specific use case I have in mind is making a self-rally roll, which calls for a **_WIL_** roll with a bane, but I couldn't spot a way to do that without the player having to manually add the bane to the roll. And manually adding the bane isn't straightforward either because the `rollAttribute` method exposed on `game.dragonbane` skips the dialog entirely.

This would allow me to use this code inside the Argon HUD module:
```javascript
game.dragonbane.rollAttribute(this.actor, 'WIL', { manualBanes: 1 });
```

From my local testing (console and chat message for the result):
<img width="748" alt="Screen Shot 2024-03-06 at 12 29 02 AM" src="https://github.com/pafvel/dragonbane/assets/68707/e8531772-709d-40bb-9f0f-584885466de5">
<img width="286" alt="Screen Shot 2024-03-06 at 12 18 43 AM" src="https://github.com/pafvel/dragonbane/assets/68707/d19473c3-4972-4333-8e2b-9a7a0b9fdd41">

The tooltip output isn't as good as I was aiming for, but it's late and I didn't manage to work out a way to compress `['Manual', 'Manual']` to `['Manual (x2)']` without a bunch more changes to parts of the code I'm less familiar with.

Happy to make any changes you feel are appropriate.