### PR TITLE
Add data to give AA access to ability uses

### DIFF
--- a/modules/character-sheet.js
+++ b/modules/character-sheet.js
@@ -1254,9 +1254,9 @@ export default class DoDCharacterSheet extends ActorSheet {
                             this.actor.update({"system.willPoints.value": newWP});
                             //content = game.i18n.format("DoD.ability.useWithWP", {actor: this.actor.name, uuid: item.uuid, wp: wp});
                             content = `
-                            <p>
-                                ${game.i18n.format("DoD.ability.useWithWP", {actor: this.actor.name, uuid: item.uuid, wp: wp})}
-                            </p>
+                            <div>
+                                <p class="ability-use" data-ability-id="${item.id}">${game.i18n.format("DoD.ability.useWithWP", {actor: this.actor.name, uuid: item.uuid, wp: wp})}</p>
+                            </div>
                             <div class="damage-details permission-observer" data-actor-id="${this.actor.uuid}">
                                 <i class="fa-solid fa-circle-info"></i>
                                 <div class="expandable" style="text-align: left; margin-left: 0.5em">


### PR DESCRIPTION
Wraps the message about ability use in a `div p`, adds the class `ability-use` and attr `data-ability-id` to that `p`.

Corresponding PR: https://github.com/otigon/automated-jb2a-animations/pull/701