### PR TITLE
Fix warning if over-encumbered

### DIFF
--- a/modules/character-sheet.js
+++ b/modules/character-sheet.js
@@ -409,7 +409,7 @@ export default class DoDCharacterSheet extends ActorSheet {
         sheetData.encumbrance = Math.round(100 * sheetData.encumbrance) / 100;
 
         if (this.actor.type === "character") {
-            sheetData.overEncumbered = sheetData.encumbrance > sheetData.maxEncumbrance;
+            sheetData.overEncumbered = sheetData.encumbrance > sheetData.actor.system.maxEncumbrance.value;
         }
     }
 


### PR DESCRIPTION
In 1.9.0 maxEncumbrance was moved from the character sheet to the actor causing the over-encumbrance check to fail since then. This merge request fixes #76 