### PR TITLE
handle extra damage for Monster

### DIFF
--- a/modules/character-sheet.js
+++ b/modules/character-sheet.js
@@ -513,6 +513,7 @@ export default class DoDCharacterSheet extends BaseActorSheet {
     _processSelectMonsterAttack(form, table) {
         let elements = form.getElementsByClassName("selectMonsterAttack");
         let element = elements.length > 0 ? elements[0] : null;
+        
         if (element) {
             const value = parseInt(element.value);
             if (value > 0) {

--- a/modules/chat.js
+++ b/modules/chat.js
@@ -14,7 +14,8 @@ export function addChatListeners(_app, html, _data) {
     DoD_Utility.addHtmlEventListener(html, "click", "button.push-roll", onPushRoll);
     DoD_Utility.addHtmlEventListener(html, "click", ".damage-details", onExpandableClick);
     DoD_Utility.addHtmlEventListener(html, 'click contextmenu', '.table-roll', DoD_Utility.handleTableRoll.bind(DoD_Utility));
-}
+    DoD_Utility.addHtmlEventListener(html, "click", "button.monster-extra-dmg", onMonsterExtraDamageRoll);  
+} 
 
 export function addChatMessageContextMenuOptions(_html, options) {
 
@@ -883,3 +884,30 @@ export function onExpandableClick(event) {
       tip.classList.toggle("expanded", message._expanded);
     }
   }
+    
+async function onMonsterExtraDamageRoll(event){
+    event.stopPropagation();
+    event.preventDefault();
+    const element = event.target;
+    const extraDamage = element.dataset.extraDamage;
+    const targets = element.dataset.targetId.split(",");;
+    const monster = await game.actors.get(element.dataset.monster);
+    targets.forEach(async target => {
+        let targetActor
+        if(target.includes("Token")){
+            targetActor = await fromUuid(target)
+        }
+        else{
+            targetActor = await game.actors.get(target)
+        }
+        const damageData = {
+            actor: monster,
+            damage: extraDamage,
+            target: targetActor,
+            damageType: game.i18n.localize("DoD.damageTypes.none")
+        };
+
+        inflictDamageMessage(damageData)
+    })
+
+}

--- a/modules/utility.js
+++ b/modules/utility.js
@@ -298,12 +298,14 @@ export default class DoD_Utility {
         );
         let targetIDs =[];
         targetIDs = targetsTokens.map(token => {
-            if (token.document.actor.type === "character") {
+            if (token.document.actor.type === "character" &&  token.document.hasStatusEffect("prone")) {
                 return token.document.actor.id;
             } else {
-                return token.document.uuid; // or undefined or some placeholder
+                if( token.document.hasStatusEffect("prone")){
+                    return token.document.uuid; 
+                }
             }       
-        });
+        }).filter(id => id !== undefined);
         if(isProne === true){
             messageData.content += `<button class="chat-button monster-extra-dmg" data-target-id=${targetIDs} data-extra-damage="D6" data-monster=${actor.id}>${game.i18n.localize("DoD.ui.dialog.extraDamage")}</button>`
                 }        // Create the chat message

--- a/modules/utility.js
+++ b/modules/utility.js
@@ -292,8 +292,21 @@ export default class DoD_Utility {
             rollHTML: table.displayRoll && roll ? await roll.render() : null,
             table: table
         });
-  
-        // Create the chat message
+        const targetsTokens = Array.from(game.user.targets);
+        const isProne = targetsTokens.some(token => 
+            token.document.hasStatusEffect("prone")
+        );
+        let targetIDs =[];
+        targetIDs = targetsTokens.map(token => {
+            if (token.document.actor.type === "character") {
+                return token.document.actor.id;
+            } else {
+                return token.document.uuid; // or undefined or some placeholder
+            }       
+        });
+        if(isProne === true){
+            messageData.content += `<button class="chat-button monster-extra-dmg" data-target-id=${targetIDs} data-extra-damage="D6" data-monster=${actor.id}>${game.i18n.localize("DoD.ui.dialog.extraDamage")}</button>`
+                }        // Create the chat message
         ChatMessage.applyRollMode(messageData, game.settings.get("core", "rollMode"));
         return ChatMessage.create(messageData);
     }


### PR DESCRIPTION
when target of monster atack have prone condition it add button to monster atack chat mesage to roll extra damage, creating inflict damge mesage. If multiple target selected roll extra damage for each target indivitualy, handel NPC as well, compatible with v12 and v13