### PR TITLE
Spells can deal WP Damage and apply Condition

### DIFF
--- a/dragonbane.js
+++ b/dragonbane.js
@@ -88,7 +88,21 @@ function registerHandlebarsHelpers() {
         }
         return result;
     });
-
+    Handlebars.registerHelper({
+        eq: (v1, v2) => v1 === v2,
+        ne: (v1, v2) => v1 !== v2,
+        lt: (v1, v2) => v1 < v2,
+        gt: (v1, v2) => v1 > v2,
+        lte: (v1, v2) => v1 <= v2,
+        gte: (v1, v2) => v1 >= v2,
+        not: (v1) => !v1,
+        and() {
+            return Array.prototype.every.call(arguments, Boolean);
+        },
+        or() {
+            return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
+        },
+    });
     Handlebars.registerHelper("dicePattern", () => new Handlebars.SafeString(DICE_FORMULA));
     Handlebars.registerHelper("spellDamagePattern", () => new Handlebars.SafeString(String.raw`-?${DICE_FORMULA}\s*(?:[sS]lashing|[pP]iercing|[bB]ludgeoning)?`));
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -127,7 +127,8 @@
             "agl": "Dazed",
             "int": "Angry",
             "wil": "Scared",
-            "cha": "Disheartened"
+            "cha": "Disheartened",
+            "none": "None"
         },
         "currency": {
             "gold": "Gold",
@@ -345,7 +346,9 @@
             "rangeType": "Range",
             "rank": "Rank",
             "requirement": "Requirement",
-            "school": "School of Magic"
+            "school": "School of Magic",
+            "damagewP": "Damage WP",
+            "applyCondition": "Apply Condition"
         },
         "spellDurationTypes": {
             "instant": "Instant",

--- a/lang/en.json
+++ b/lang/en.json
@@ -139,10 +139,11 @@
             "none": "Damage",
             "bludgeoning": "Bludgeoning Damage",
             "piercing": "Piercing Damage",
-            "slashing": "Slashing Damage",
+            "slashing": "Slashing Damage",  
             "bludgeoningTooltip": "Bludgeoning Damage",
             "piercingTooltip": "Piercing Damage",
-            "slashingTooltip": "Slashing Damage"
+            "slashingTooltip": "Slashing Damage",
+            "damageWP": "Will Points Damage"
         },
         "dice": {
             "d": "D",
@@ -283,10 +284,14 @@
             "weaponRoll": "<b>{action}</b> with @UUID[{uuid}] <b>{result}</b>",
             "weaponRollTarget": "<b>{action}</b> with @UUID[{uuid}] targeting <b>{target}</b> <b>{result}</b>",
             "damage": "<b>{actor}</b> inflicts <b>{damage}</b> points <b>{damageType}</b>.",
+            "damageWP": "<b>{actor}</b> inflicts <b>{damage}</b> points <b>{damageType}</b>",
+            "conditions": "<b>{actor}</b> inflicts <b>{conditions}</b>.",
+            "conditionsTarget": "<b>{actor}</b> inflicts <b>{conditions}</b> on <b>{target}</b>.",
             "damageWeapon": "<b>{actor}</b> inflicts <b>{damage}</b> points <b>{damageType}</b> using <b>{weapon}</b>.",
             "damageIgnoreArmor": "<b>{actor}</b> inflicts <b>{damage}</b> points <b>{damageType} ignoring armor</b> using <b>{weapon}</b>.",
             "damageTarget": "<b>{actor}</b> inflicts <b>{damage}</b> points <b>{damageType}</b> on <b>{target}</b>.",
             "damageWeaponTarget": "<b>{actor}</b> inflicts <b>{damage}</b> points <b>{damageType}</b> on <b>{target}</b> using <b>{weapon}</b>.",
+            "damageWPTarget": "<b>{actor}</b> inflicts <b>{damage}</b> points <b>{damageType}</b> on <b>{target}</b>.",
             "damageIgnoreArmorTarget": "<b>{actor}</b> inflicts <b>{damage}</b> points <b>{damageType}</b> on <b>{target}</b> <b>ignoring armor</b> using <b>{weapon}</b>.",
             "healing": "<b>{actor}</b> heals for <b>{damage}</b> HP.",
             "healingTarget": "<b>{actor}</b> heals <b>{target}</b> for <b>{damage}</b> HP.",
@@ -550,6 +555,9 @@
             },
             "chat": {
                 "damageApplied": "<b>{damage}</b> HP damage applied to <b>{actor}</b>.",
+                "damageWPApplied": "<b>{damage}</b> WP damage applied to <b>{actor}</b>",
+                "conditionApplied": "Condition <b>{condition}</b> applied to <b>{actor}</b>",
+                "alredyHeveCondition": "<b>{actor}</b> alredy have condition <b>{condition}</b>",
                 "damageAppliedDetails": "{damage} damage vs {armor} armor rating.",
                 "damageAppliedMultiplier": "x{multiplier} multiplier.",
                 "healingApplied": "<b>{actor}</b> heals <b>{damage}</b> HP.",
@@ -581,8 +589,14 @@
                 "penetrating": "Penetrating",
                 "damageDetailMultiplier": "Multiplier",
                 "damageDetailTotal": "Total damage",
+                "damageDetailDamageWP": "Total WP Damage",
                 "updateTarget": "Update Target",
-                "criticalHit": "Critical Hit"
+                "criticalHit": "Critical Hit",
+                "restorWPApplied":"<b>{actor}</r> restor <b>{damage}</b> WP",
+                "conditionRestore": "<b>{actor}</b> heals condition <b>{condition}</b>",
+                "applyConditions": "Apply Condition",
+                "rollDamageAndApplyConditions": "Roll Damage and aplly condition",
+                "rollDamageWP": "Roll WP Damage "
             },
             "dialog": {
                 "banes": "Banes",

--- a/modules/actor.js
+++ b/modules/actor.js
@@ -609,7 +609,32 @@ export class DoDActor extends Actor {
         }
         return newValue;
     }
+    async applyWillpowerDamage(damage) {
+        const haveWP = this.system?.willPoints;
+        if(haveWP){
+            const currentWP = haveWP.value;
+            const newWP = currentWP - damage < 0 ? 0 : currentWP - damage;
+            await this.update({["system.willPoints.value"]: newWP});
+            return {currentWP: currentWP, newWP:newWP}
+        }
+        else{
+            return {currentWP: undefined, newWP:undefined};
+        }
+    }
+    async applyConditions(condition, value){
+        const haveConditions = this.system?.conditions;;
+        if(haveConditions){
+            if((!this.hasCondition(condition) && value) ||(this.hasCondition(condition) && !value)){
+            this.updateCondition(condition, value)
+            return true
+            }else{
+                return false
+            }
+        }else{
+            return false
+        }
 
+    }
     findAbility(abilityName) {
         let name = abilityName.toLowerCase();
         return this.items.find(item => item.type === "ability" && item.name.toLowerCase() === name);

--- a/modules/chat.js
+++ b/modules/chat.js
@@ -12,6 +12,9 @@ export function addChatListeners(_app, html, _data) {
     DoD_Utility.addHtmlEventListener(html, "click", ".treasure-roll", onTreasureRoll);
     DoD_Utility.addHtmlEventListener(html, "click", "[data-action='rollWeaponDamage']", onRollWeaponDamage);
     DoD_Utility.addHtmlEventListener(html, "click", "[data-action='rollSpellDamage']", onRollSpellDamage);
+    DoD_Utility.addHtmlEventListener(html, "click", "[data-action='applySpellConditions']", onApplySpellConditions);
+    DoD_Utility.addHtmlEventListener(html, "click", "[data-action='rollSpellDamageWP']", onRollSpellDamageWP);
+
     DoD_Utility.addHtmlEventListener(html, "click", "button.critical-roll", onCriticalDamageRoll);
     DoD_Utility.addHtmlEventListener(html, "click", "button.push-roll", onPushRoll);
     DoD_Utility.addHtmlEventListener(html, "click", ".damage-details", onExpandableClick);
@@ -484,9 +487,9 @@ async function onRollSpellDamage(event) {
 
     if (!(actor && spell?.isDamaging)) return;
 
-    const { formula, damageType } = DoD_Utility.parseDamageString(spell.system.damage);
+    const { formula } = DoD_Utility.parseDamageString(spell.system.damage);
     let damage = formula;
-
+    const damageType = spell.system.damageType;
     if (!damage) {
         DoD_Utility.WARNING("DoD.WARNING.cannotEvaluateFormula");
         return;
@@ -523,6 +526,57 @@ async function onRollSpellDamage(event) {
     }
     await inflictDamageMessage(damageData);
 }
+async function onRollSpellDamageWP(event) {
+    if (event.detail === 2) { // double-click
+        return;
+    };
+    event.stopPropagation();
+    event.preventDefault();
+
+    // get the message
+    const messageId = event.target.closest(".chat-message")?.dataset.messageId;
+    const message = game.messages.get(messageId);
+    if (!message) return;
+
+    const context = message.system.toContext();
+    const actor = context.actor;
+    const spell = context.spell;
+
+    if (!(actor && spell?.isDamagingWP)) return;
+
+    const { formula } = DoD_Utility.parseDamageString(spell.system.damageWP);
+    let damage = formula;
+
+    if (!damage) {
+        DoD_Utility.WARNING("DoD.WARNING.cannotEvaluateFormula");
+        return;
+    }    
+
+
+    const damageData = {
+        actor: actor,
+        weapon: spell,
+        damage: damage,
+        isHealing: context.isHealing,
+        doubleSpellDamage: context.criticalEffect === "doubleDamage",
+        target: context.targetActor
+    };
+
+    if (!damageData.target) {
+        const targets = Array.from(game.user.targets)
+        if (targets.length > 0) {
+            for (const target of targets) {
+                damageData.target = target.actor;
+                await inflictDamageWPMessage(damageData);
+            }
+            return;
+        }
+    }
+    await inflictDamageWPMessage(damageData);
+}
+
+async function onApplySpellConditions(event) {}
+
 
 async function onCriticalDamageRoll(event) {
     if (event.detail === 2) { // double-click
@@ -755,6 +809,60 @@ export async function inflictDamageMessage(damageData) {
     });
 
     rollDamageMessage.toMessage(roll);
+}
+
+export async function inflictDamageWPMessage(damageData) {
+ let formula = damageData.damage;
+
+    let isHealing = false;
+    if (formula[0] === "-") {
+        isHealing = true;
+        formula = formula.substring(1);
+    } else {
+        isHealing = damageData.isHealing;
+    }
+
+    // Add "1" in front of D to make sure the first roll term is a Die.
+    if (formula[0] === "d" || formula[0] === "D") {
+        formula = "1" + formula;
+    }
+
+    // Check if target have wp
+    if (damageData.actor?.isMonster && damageData.target && !isHealing) {
+        const targetToken = canvas.scene.tokens.find(t => t.actor.uuid === damageData.target.uuid);
+        if (targetToken && (targetToken.actor?.system?.willpower?.value === 0 || targetToken.actor?.system?.willpower?.value === undefined)) {
+            createChatMessage(game.i18n.format("DoD.ui.chat.targetNoWillpower", {target: targetToken.name}));
+            return;
+        }
+    }
+    
+    if (damageData.doubleSpellDamage) {
+        formula = "2*(" + formula + ")";
+    }
+    const roll = new Roll(formula);
+
+    if (damageData.doubleWeaponDamage && roll.terms.length > 0) {
+        let term = roll.terms[0];
+        if (term instanceof foundry.dice.terms.Die) {
+            term.number *= 2;
+        }
+    }
+
+    await roll.roll({});
+
+    const rollDamageMessage = DoDRollDamageMessageData.fromContext({
+        actor: damageData.actor,
+        weapon: damageData.weapon,
+        targetActor: damageData.target,
+        damage: roll.total,
+        formula: roll.formula,
+        isHealing: isHealing,
+        damageWP: true,
+    });
+    rollDamageMessage.toMessage(roll);
+
+
+
 }
 
 export async function applyDamageMessage(damageData) {

--- a/modules/chat.js
+++ b/modules/chat.js
@@ -12,8 +12,7 @@ export function addChatListeners(_app, html, _data) {
     DoD_Utility.addHtmlEventListener(html, "click", ".treasure-roll", onTreasureRoll);
     DoD_Utility.addHtmlEventListener(html, "click", "[data-action='rollWeaponDamage']", onRollWeaponDamage);
     DoD_Utility.addHtmlEventListener(html, "click", "[data-action='rollSpellDamage']", onRollSpellDamage);
-    DoD_Utility.addHtmlEventListener(html, "click", "[data-action='applySpellConditions']", onApplySpellConditions);
-    DoD_Utility.addHtmlEventListener(html, "click", "[data-action='rollSpellDamageWP']", onRollSpellDamageWP);
+
 
     DoD_Utility.addHtmlEventListener(html, "click", "button.critical-roll", onCriticalDamageRoll);
     DoD_Utility.addHtmlEventListener(html, "click", "button.push-roll", onPushRoll);
@@ -100,18 +99,22 @@ function getTarget(element) {
     return target;
 }
 
-function dealTargetDamage(li, multiplier = 1, ignoreArmor = false) {
+async function dealTargetDamage(li, multiplier = 1, ignoreArmor = false) {
     const damageData = {};
     const element = li.querySelector(".damage-roll") || li.querySelector(".dice-total");
-
+    const message = await game.messages.get(li.dataset.messageId);
     damageData.damage = element.dataset.damage ?? Number(element.innerText);
-    damageData.damageType = element.dataset.damageType?.substring(String("DoD.damageTypes.").length);
+    
     damageData.actor = getTarget(element);
     damageData.multiplier = multiplier;
     damageData.ignoreArmor = ignoreArmor || element.dataset.ignoreArmor;
     damageData.penetrating = Number(element.dataset.penetrating) || 0;
+    damageData.damageWP = message.system.damageWPTotal;
+    damageData.isDamageWP = message.system.damageWP;
+    damageData.condition = message.system.conditions;
+    damageData.damageType = message.system.damageType;
 
-    if (!(damageData.actor instanceof DoDActor)) {
+   if (!(damageData.actor instanceof DoDActor)) {
         DoD_Utility.WARNING("TOKEN.WarningNoActor");
     }
     else if (!damageData.actor.isOwner) {
@@ -281,13 +284,23 @@ export function addChatMessageContextMenuOptions(_html, options) {
         return false;
     }
 
-    const undoDamage = function(li) {
+    const undoDamage = async function(li) {
         const element = li.querySelector(".damage-message");
+        const message = await game.messages.get(li.dataset.messageId);
+        const totalWPDamage = message?.system?.totalWPDamage;
+        const condition = message?.system.condition;
+        const applyCondition = message?.system.applyCondition;
+        const isDamageWP = message?.system.isDamageWP;
+
         const healingData = {
             actor: DoD_Utility.getActorFromUUIDSync(element?.dataset.actorId),
-            damage: Number(element?.dataset.damage)
-        };
-        applyHealingMessage(healingData);
+            damage: Number(element?.dataset.damage),
+            totalWPDamage: totalWPDamage,
+            condition: condition,
+            applyCondition: applyCondition,
+            isDamageWP: isDamageWP
+        };     
+         applyHealingMessage(healingData);
     }
 
 
@@ -484,13 +497,13 @@ async function onRollSpellDamage(event) {
     const context = message.system.toContext();
     const actor = context.actor;
     const spell = context.spell;
+    const isDamaging = (spell.isDamaging || spell.isDamagingWP || spell.applyConditions);
+    if (!(actor && isDamaging)) return;
 
-    if (!(actor && spell?.isDamaging)) return;
-
-    const { formula } = DoD_Utility.parseDamageString(spell.system.damage);
-    let damage = formula;
+    const { formula: formula } = DoD_Utility.parseDamageString(spell.system.damage );
+    let damage = formula ?? "";
     const damageType = spell.system.damageType;
-    if (!damage) {
+    if (!damage && spell.isDamaging ) {
         DoD_Utility.WARNING("DoD.WARNING.cannotEvaluateFormula");
         return;
     }
@@ -503,11 +516,19 @@ async function onRollSpellDamage(event) {
             damage += spell.system.damagePerPowerlevel;
         }
     }
+    const { formula: formulWp } = DoD_Utility.parseDamageString(spell.system.damageWP);
+    let damageWP = formulWp;
 
+    if (!damageWP && spell.isDamagingWP) {
+        DoD_Utility.WARNING("DoD.WARNING.cannotEvaluateFormula");
+        return;
+    }
     const damageData = {
         actor: actor,
         weapon: spell,
         damage: damage,
+        damageWp: damageWP,
+        conditions: spell.system.applyConditions,
         damageType: damageType,
         isHealing: context.isHealing,
         doubleSpellDamage: context.criticalEffect === "doubleDamage",
@@ -526,56 +547,7 @@ async function onRollSpellDamage(event) {
     }
     await inflictDamageMessage(damageData);
 }
-async function onRollSpellDamageWP(event) {
-    if (event.detail === 2) { // double-click
-        return;
-    };
-    event.stopPropagation();
-    event.preventDefault();
 
-    // get the message
-    const messageId = event.target.closest(".chat-message")?.dataset.messageId;
-    const message = game.messages.get(messageId);
-    if (!message) return;
-
-    const context = message.system.toContext();
-    const actor = context.actor;
-    const spell = context.spell;
-
-    if (!(actor && spell?.isDamagingWP)) return;
-
-    const { formula } = DoD_Utility.parseDamageString(spell.system.damageWP);
-    let damage = formula;
-
-    if (!damage) {
-        DoD_Utility.WARNING("DoD.WARNING.cannotEvaluateFormula");
-        return;
-    }    
-
-
-    const damageData = {
-        actor: actor,
-        weapon: spell,
-        damage: damage,
-        isHealing: context.isHealing,
-        doubleSpellDamage: context.criticalEffect === "doubleDamage",
-        target: context.targetActor
-    };
-
-    if (!damageData.target) {
-        const targets = Array.from(game.user.targets)
-        if (targets.length > 0) {
-            for (const target of targets) {
-                damageData.target = target.actor;
-                await inflictDamageWPMessage(damageData);
-            }
-            return;
-        }
-    }
-    await inflictDamageWPMessage(damageData);
-}
-
-async function onApplySpellConditions(event) {}
 
 
 async function onCriticalDamageRoll(event) {
@@ -793,22 +765,43 @@ export async function inflictDamageMessage(damageData) {
             term.number *= 2;
         }
     }
-
-    await roll.roll({});
+     const rollWp = new Roll(damageData.damageWp);
+    if(damageData.damageWp) {
+       
+        await rollWp.roll({});
+        damageData.damageWP = true;
+        damageData.damageWPTotal = rollWp.total;
+        damageData.damageWpFormula = rollWp.formula;
+    }else{
+        damageData.damageWP = false;
+        damageData.damageWPTotal = 0;
+        damageData.damageWpFormula = "";
+    }
+    if(formula !== ""){
+        await roll.roll({});
+    }
 
     const rollDamageMessage = DoDRollDamageMessageData.fromContext({
         actor: damageData.actor,
         weapon: damageData.weapon,
         targetActor: damageData.target,
-        damage: roll.total,
+        damage: roll?.total,
         damageType: damageData.damageType,
-        formula: roll.formula,
+        formula: roll?.formula,
         isHealing: isHealing,
         ignoreArmor: damageData.ignoreArmor,
-        penetrating: damageData.penetrating ?? 0
+        penetrating: damageData.penetrating ?? 0,
+        damageWP: damageData.damageWP,
+        damageWPTotal: damageData.damageWPTotal,
+        damageWpFormula: damageData.damageWpFormula,
+        conditions: damageData.conditions,
     });
-
-    rollDamageMessage.toMessage(roll);
+    let rollToMsg;
+    if(formula !== ""){
+        rollDamageMessage.toMessage(roll);
+    }else if(damageData.damageWP){
+        rollDamageMessage.toMessage(rollWp);
+    }
 }
 
 export async function inflictDamageWPMessage(damageData) {
@@ -873,18 +866,59 @@ export async function applyDamageMessage(damageData) {
     const multiplier = damageData.multiplier;
     const ignoreArmor = damageData.ignoreArmor;
     const penetrating = damageData.penetrating ?? 0;
+    const isDamageWP = damageData.isDamageWP ?? false;
+    const damageWPTotal = damageData.damageWP ?? 0;
+    const conditions = damageData.condition ?? "none";
     const armorValue = ignoreArmor ? 0 : Math.max(0, actor.getArmorValue(damageType) - penetrating);
     const damageToApply = Math.max(0, Math.floor((damage - armorValue) * multiplier));
     const oldHP = actor.system.hitPoints.value;
-
-    if (damageToApply > 0) {
-        await actor.applyDamage(damageToApply);
-    }
-    const newHP = actor.system.hitPoints.value;
-    const damageTaken = oldHP - newHP;
-
     const actorName = actor.isToken ? actor.token.name : actor.name;
     const token = canvas.scene.tokens.find(t => t.actor.uuid === actor.uuid);
+    let WPdamageText = "";
+    let conditionText = "";
+    let HPDamageText = "";
+    let damageTaken = 0;
+    let currentWP = 0;
+    let newWP = 0;
+    let totalWPDamage = 0;
+    let newHP = actor.system.hitPoints.value;
+    let WPDamageDetails = "";
+    let applyCondition = false;
+    if (damageToApply > 0) {
+        await actor.applyDamage(damageToApply);
+        newHP = actor.system.hitPoints.value;
+        damageTaken = oldHP - newHP;
+        HPDamageText = game.i18n.format("DoD.ui.chat.damageApplied", {damage: damageTaken, actor: actorName});
+    }
+    if (isDamageWP && damageWPTotal > 0) {
+       const WP= await actor.applyWillpowerDamage(damageWPTotal);
+       currentWP = WP.currentWP;
+       newWP = WP.newWP;
+       if(currentWP !== undefined && newWP !== undefined){
+        if(HPDamageText !== ""){
+            WPdamageText += "<br>"
+        }
+        totalWPDamage = (currentWP - newWP);
+        WPdamageText += game.i18n.format("DoD.ui.chat.damageWPApplied", {damage: totalWPDamage, actor: actorName});
+        WPDamageDetails = `
+         <b>${game.i18n.localize("DoD.ui.chat.damageDetailDamageWP")}:</b> ${totalWPDamage}<br>
+         <b>${game.i18n.localize("DoD.ui.character-sheet.wp")}:</b> ${currentWP} <i class="fa-solid fa-arrow-right"></i> ${newWP}<br>`
+       }
+    }
+    if(conditions !== "none"){
+        applyCondition = await actor.applyConditions(conditions, true);
+        if(applyCondition){
+        if(HPDamageText !== "" || WPdamageText !== ""){
+            conditionText += "<br>"
+        }
+            conditionText += game.i18n.format("DoD.ui.chat.conditionApplied", {condition: game.i18n.localize("DoD.conditions." + conditions), actor: actorName});
+        }else{
+            conditionText += game.i18n.format("DoD.ui.chat.alredyHeveCondition",{condition: game.i18n.localize("DoD.conditions." + conditions), actor: actorName})
+        }
+    }
+
+
+
 
     const permissionKey = DoD_Utility.getViewDamagePermission().toLowerCase();
 
@@ -965,7 +999,10 @@ export async function applyDamageMessage(damageData) {
 
     let html = `
         <div class="damage-message permission-${permissionKey}" data-damage="${damageTaken}" data-actor-id="${actor.uuid}">
-            ${game.i18n.format("DoD.ui.chat.damageApplied", {damage: damageTaken, actor: actorName})}
+            ${HPDamageText}
+            ${WPdamageText}
+            ${conditionText}
+            <br>
             ${message}
             <div class="damage-details permission-observer" data-actor-id="${actor.uuid}">
                 <i class="fa-solid fa-circle-info"></i>
@@ -975,6 +1012,7 @@ export async function applyDamageMessage(damageData) {
                     <b>${game.i18n.localize("DoD.ui.chat.damageDetailMultiplier")}:</b> x${multiplier}<br>
                     <b>${game.i18n.localize("DoD.ui.chat.damageDetailTotal")}:</b> ${damageToApply}<br>
                     <b>${game.i18n.localize("DoD.ui.character-sheet.hp")}:</b> ${oldHP} <i class="fa-solid fa-arrow-right"></i> ${newHP}<br>
+                    ${WPDamageDetails}
                 </div>
             </div>            
         </div>
@@ -984,7 +1022,13 @@ export async function applyDamageMessage(damageData) {
         </div>`;
     ChatMessage.create({ 
         user: game.user.id,
-        content: html
+        content: html,
+        system: {
+            totalWPDamage: totalWPDamage,
+            condition: conditions,
+            applyCondition: applyCondition,
+            isDamageWP: isDamageWP
+        }
     });
 }
 
@@ -992,23 +1036,59 @@ export async function applyHealingMessage(damageData) {
 
     const actor = damageData.actor;
     const damage = damageData.damage;
+    const applyCondition = damageData?.applyCondition ?? false;
+    const totalWPDamage = damageData?.totalWPDamage ?? 0;
+    const conditions = damageData?.condition ?? "none";
+    const isDamageWP = damageData?.isDamageWP ?? false;
     const oldHP = actor.system.hitPoints.value;
     let newHP = oldHP;
 
     if (damage > 0) {
         newHP = await actor.applyDamage(-damage);
     }
-
+    let WPdamageText = "";
+    let conditionText = "";
+    let HPDamageText = "";
+    let currentWP = 0;
+    let newWP = 0; 
+    let WPDamageDetails = "";
+    let conditionHasBennApply = false;
     const actorName = actor.isToken ? actor.token.name : actor.name;
+    if (isDamageWP && totalWPDamage > 0) {
+       const WP= await actor.applyWillpowerDamage(-totalWPDamage);
+       currentWP = WP.currentWP;
+       newWP = WP.newWP;
+       if(currentWP !== undefined && newWP !== undefined){
+        if(HPDamageText !== ""){
+            WPdamageText += "<br>"
+        }
+        WPdamageText += game.i18n.format("DoD.ui.chat.restorWPApplied", {damage: totalWPDamage, actor: actorName});
+        WPDamageDetails = `
+         <b>${game.i18n.localize("DoD.ui.character-sheet.wpp")}:</b> ${currentWP} <i class="fa-solid fa-arrow-right"></i> ${newWP}<br>`
+       }
+    }
+    if(applyCondition && conditions !== "none"){
+        conditionHasBennApply = await actor.applyConditions(conditions, false);
+        if(conditionHasBennApply){
+        if(HPDamageText !== "" || WPdamageText !== ""){
+            conditionText += "<br>"
+        }
+            conditionText += game.i18n.format("DoD.ui.chat.conditionRestore", {condition: game.i18n.localize("DoD.conditions." + conditions), actor: actorName});
+        }
+    }
+    
     const permissionKey = DoD_Utility.getViewDamagePermission().toLowerCase();
 
     const msg = `
     <div class="permission-${permissionKey}" data-actor-id="${actor.uuid}">
         ${game.i18n.format("DoD.ui.chat.healingApplied", {damage: newHP - oldHP, actor: actorName})}
+        ${WPdamageText}
+        ${conditionText}
         <div class="damage-details permission-observer" data-actor-id="${actor.uuid}">
             <i class="fa-solid fa-circle-info"></i>
             <div class="expandable" style="text-align: left; margin-left: 0.5em">
                 <b>${game.i18n.localize("DoD.ui.character-sheet.hp")}:</b> ${oldHP} <i class="fa-solid fa-arrow-right"></i> ${newHP}<br>
+                ${WPDamageDetails}
             </div>
         </div>            
     </div>

--- a/modules/config.js
+++ b/modules/config.js
@@ -134,6 +134,15 @@ DoD.attributes = {
     "cha": "DoD.attributes.cha",
     "none": "DoD.attributes.none",
 };
+DoD.condition = {
+        str: "DoD.conditions.str",
+        con: "DoD.conditions.con",
+        agl: "DoD.conditions.agl",
+        int: "DoD.conditions.int",
+        wil: "DoD.conditions.wil",
+        cha: "DoD.conditions.cha",
+        none: "DoD.conditions.none",
+}
 
 DoD.activeEffectAttributes = [
     {

--- a/modules/data/items/spellData.js
+++ b/modules/data/items/spellData.js
@@ -14,6 +14,9 @@ export default class DoDSpellData extends DoDItemBaseData {
             areaOfEffect: new fields.StringField({ required: true, initial: "" }),
             duration: new fields.StringField({ required: true, initial: "instant" }),
             damage: new fields.StringField({ required: true, initial: "" }),
+            damageType: new fields.StringField({ required: true, initial: "none", choices: CONFIG.DoD.damageTypes  }),
+            damageWP: new fields.StringField({ required: true, initial: "" }),
+            applyConditions: new fields.StringField({ required: true, initial: "none", choices: CONFIG.DoD.condition }),
             damagePerPowerlevel: new fields.StringField({ required: true, initial: "" }),
             memorized: new fields.BooleanField({ required: true, initial: false }),
         });

--- a/modules/data/messages/roll-damage-message.js
+++ b/modules/data/messages/roll-damage-message.js
@@ -12,6 +12,7 @@ export default class DoDRollDamageMessageData extends DoDChatMessageBaseData {
             weaponUuid: new fields.StringField({ required: false, initial: "" }),
             targetActorUuid: new fields.StringField({ required: true, initial: "" }),
             damage: new fields.NumberField({ required: true, initial: 0 }),
+            damageWP: new fields.BooleanField({ required: true, initial: false }),
             damageType: new fields.StringField({ required: true, initial: "" }),
             formula: new fields.StringField({ required: false, initial: "" }),
             isHealing: new fields.BooleanField({ required: true, initial: false }),
@@ -58,7 +59,7 @@ export default class DoDRollDamageMessageData extends DoDChatMessageBaseData {
 
         let msg = context.isHealing ?
             "DoD.roll.healing" :
-            (weaponName ? (context.ignoreArmor ? "DoD.roll.damageIgnoreArmor" : "DoD.roll.damageWeapon") : "DoD.roll.damage");
+            (weaponName ? (context.ignoreArmor ? "DoD.roll.damageIgnoreArmor" : "DoD.roll.damageWeapon") : (context.damageWP ? "DoD.roll.damageWP" : "DoD.roll.damage"));
 
         if (context.targetActor) {
             msg += "Target";

--- a/modules/data/messages/roll-damage-message.js
+++ b/modules/data/messages/roll-damage-message.js
@@ -13,11 +13,14 @@ export default class DoDRollDamageMessageData extends DoDChatMessageBaseData {
             targetActorUuid: new fields.StringField({ required: true, initial: "" }),
             damage: new fields.NumberField({ required: true, initial: 0 }),
             damageWP: new fields.BooleanField({ required: true, initial: false }),
+            damageWPTotal: new fields.NumberField({ required: true, initial: 0 }),
+            damageWpFormula: new fields.StringField({ required: false, initial: "" }),
             damageType: new fields.StringField({ required: true, initial: "" }),
             formula: new fields.StringField({ required: false, initial: "" }),
             isHealing: new fields.BooleanField({ required: true, initial: false }),
             ignoreArmor: new fields.BooleanField({ required: true, initial: false }),
             penetrating: new fields.NumberField({ required: true, initial: 0 }),
+            conditions: new fields.StringField({ required: false, initial: "none" }),
         });
     }
 
@@ -56,22 +59,48 @@ export default class DoDRollDamageMessageData extends DoDChatMessageBaseData {
         const weaponName = context.weapon ? (context.weapon?.isToken ? context.weapon.token.name : context.weapon?.name) : "";
         const targetName = context.targetActor ? (context.targetActor?.isToken ? context.targetActor.token.name : context.targetActor?.name) : "";;
         const damageTotal = Math.round(this.damage);
-
+        let content = "";
         let msg = context.isHealing ?
             "DoD.roll.healing" :
-            (weaponName ? (context.ignoreArmor ? "DoD.roll.damageIgnoreArmor" : "DoD.roll.damageWeapon") : (context.damageWP ? "DoD.roll.damageWP" : "DoD.roll.damage"));
-
+            (weaponName ? (context.ignoreArmor ? "DoD.roll.damageIgnoreArmor" : "DoD.roll.damageWeapon") : "DoD.roll.damage");
+        if( context.damageWP){
+            msg = "DoD.roll.damageWP";
+        }
         if (context.targetActor) {
             msg += "Target";
         }
-
-        const content = game.i18n.format(msg, {
+        if( context.damageWP){
+         content = game.i18n.format(msg, {
             actor: ChatMessage.getSpeaker({ actor: context.actor }).alias,
-            damage: damageTotal,
-            damageType: game.i18n.localize(context.damageType),
+            damage: this.damageWPTotal,
+            damageType: game.i18n.localize("DoD.damageTypes.damageWP"),
             weapon: weaponName,
             target: targetName
         });
+        }
+        if(context.formula !== ""){
+            if(content !== ""){
+                content += "<br>";
+            }
+            content +=  game.i18n.format(msg, {
+            actor: ChatMessage.getSpeaker({ actor: context.actor }).alias,
+            damage: damageTotal,
+            damageType: game.i18n.localize("DoD.damageTypes." + context.damageType),
+            weapon: weaponName,
+            target: targetName
+        });
+        }
+        if(this.conditions !== "none"){
+        if(content !== ""){
+                content += "<br>";
+            }
+            content += game.i18n.format("DoD.roll.conditions", {
+                conditions: game.i18n.localize("DoD.conditions." + this.conditions),
+                actor: ChatMessage.getSpeaker({ actor: context.actor }).alias
+            });
+        }
+
+
 
         const templateContext = {
             user: game.user.id,
@@ -82,7 +111,11 @@ export default class DoDRollDamageMessageData extends DoDChatMessageBaseData {
             ignoreArmor: context.ignoreArmor,
             penetrating: context.penetrating,
             target: context.targetActor,
-            isHealing: context.isHealing
+            isHealing: context.isHealing,
+            damageWP: this.damageWP,
+            damageWPTotal: this.damageWPTotal,
+            damageWpFormula: this.damageWpFormula
+
         };
         const renderedTemplate = await DoD_Utility.renderTemplate(this.template, templateContext);
 

--- a/modules/data/messages/spell-test-message.js
+++ b/modules/data/messages/spell-test-message.js
@@ -9,6 +9,9 @@ export default class DoDSpellTestMessageData extends DoDSkillTestMessageData {
         const { fields } = foundry.data;
         return this.mergeSchema(super.defineSchema(), {
             isDamaging: new fields.BooleanField({ required: true, initial: false }),
+            isDamagingWP: new fields.BooleanField({ required: true, initial: false }),
+            applyConditions: new fields.BooleanField({ required: true, initial: false }),
+            condition: new fields.StringField({ required: false, initial: "" }),
             isHealing: new fields.BooleanField({ required: true, initial: false }),
             powerLevel: new fields.NumberField({ required: true, initial: 0 }),
             spellUuid: new fields.StringField({ required: true, initial: "" }),

--- a/modules/data/messages/test-message-base.js
+++ b/modules/data/messages/test-message-base.js
@@ -96,7 +96,6 @@ export default class DoDTestMessageBaseData extends DoDChatMessageBaseData {
     async toMessage(roll) {
         const messageData = await this.createMessageData(roll);
         const msg = await roll.toMessage(messageData);
-        console.log(msg)
     }
 
     async onCritical(_message) {

--- a/modules/item.js
+++ b/modules/item.js
@@ -114,6 +114,19 @@ export class DoDItem extends Item {
         }
         return false;
     }
+    get isDamagingWP() {
+        if (this.type === "spell") {
+            return this.system.damageWP?.length > 0;
+        }
+        return false;
+    }
+
+    get applyConditions() {
+        if (this.type === "spell") {
+            return this.system.applyConditions !== "none";
+        }
+        return false;
+    }
 
     get isHealing() {
         return this.isDamaging && this.system.damage[0] === "-";

--- a/modules/sheets/item/spell-sheet.js
+++ b/modules/sheets/item/spell-sheet.js
@@ -32,6 +32,7 @@ export default class DoDSpellSheet extends DoDItemBaseSheet {
         if(!context.enableRange) {
             context.system.range = "";
         }
+        context.systemFields = this.item.system.schema.fields;
         return context;
     }
 

--- a/modules/tests/spell-test.js
+++ b/modules/tests/spell-test.js
@@ -150,8 +150,9 @@ export default class DoDSpellTest extends DoDSkillTest  {
                 console.warn("Power source does not have WP or Charge", powerSource);
             }
         }
-
-        this.postRollData.isDamaging = this.spell.isDamaging;
+        
+        this.postRollData.isDamaging = (this.spell.isDamaging || this.spell.isDamagingWP || this.spell.applyConditions);
+        this.postRollData.damageHP = this.spell.isDamaging;
         this.postRollData.isHealing = this.spell.isHealing;
         this.postRollData.isDamagingWP  = this.spell.isDamagingWP;
         this.postRollData.applyConditions = this.spell.applyConditions;

--- a/modules/tests/spell-test.js
+++ b/modules/tests/spell-test.js
@@ -153,7 +153,11 @@ export default class DoDSpellTest extends DoDSkillTest  {
 
         this.postRollData.isDamaging = this.spell.isDamaging;
         this.postRollData.isHealing = this.spell.isHealing;
-
+        this.postRollData.isDamagingWP  = this.spell.isDamagingWP;
+        this.postRollData.applyConditions = this.spell.applyConditions;
+        if(this.postRollData.applyConditions) {
+            this.postRollData.condition = this.spell.system.applyConditions;
+        }
         if (this.spell.type === "recipe" && this.options.craftItem) {
             this.postRollData.craftItem = true;
             if (!this.isReroll && !this.spell.hasMaterials({ actor: this.actor, count: this.powerLevel ?? 1 })) {

--- a/templates/partials/damage-roll-message.hbs
+++ b/templates/partials/damage-roll-message.hbs
@@ -4,15 +4,26 @@
     {{#if target}} data-target-id="{{target.uuid}}" {{/if}}
 >
 {{else}}
-<div class="damage-roll"
-    data-damage="{{total}}"
-    data-damage-type="{{damageType}}"
-    {{#if ignoreArmor}} data-ignore-armor="{{ignoreArmor}}" {{/if}}
-    {{#if penetrating}} data-penetrating="{{penetrating}}" {{/if}}
-    {{#if target}} data-target-id="{{target.uuid}}" {{/if}}
->
+    {{#if (ne formula "")}}
+    <div class="damage-roll"
+        data-damage="{{total}}"
+        data-damage-type="{{damageType}}"
+        {{#if ignoreArmor}} data-ignore-armor="{{ignoreArmor}}" {{/if}}
+        {{#if penetrating}} data-penetrating="{{penetrating}}" {{/if}}
+        {{#if target}} data-target-id="{{target.uuid}}" {{/if}}
+    >
+    {{> "systems/dragonbane/templates/partials/roll.hbs"}}
+    {{/if}}
 {{/if}}
-{{> "systems/dragonbane/templates/partials/roll.hbs"}}
+{{#if damageWP}}
+<div class="damage-roll"
+    data-damageWP="{{damageWPTotal}}">
+{{> "systems/dragonbane/templates/partials/roll.hbs"
+    total=damageWPTotal
+    formula=damageWpFormula
+}}
+</div>
+{{/if}}
 </div>
 
 {{#if target}}

--- a/templates/partials/skill-roll-message.hbs
+++ b/templates/partials/skill-roll-message.hbs
@@ -53,6 +53,34 @@
                     {{/if}}
                 </button>
             {{/if}} <!-- isDamaging -->
+            {{#if isDamagingWP}}
+                <button class="chat-button magic-roll"
+                    data-action="rollSpellDamageWP"
+                    data-actor-id="{{actor.uuid}}"
+                    data-spell-id="{{spell.id}}"
+                    data-power-level="{{powerLevel}}"   
+                    data-wp-cost="{{wpCost}}"
+                    {{#if isMagicCrit }} data-is-magic-crit="{{isMagicCrit}}" {{/if}}
+                    {{#if targetActor }} data-target-id="{{targetActor.uuid}}" {{/if}}
+                    >
+                    <i class="fas fa-dice"></i>
+                    {{localize "DoD.ui.chat.rollDamageWP"}}
+                </button>
+            {{/if}} <!-- isDamagingWP -->
+            {{#if applyConditions}}
+                <button class="chat-button magic-roll"
+                    data-action="applySpellConditions"
+                    data-actor-id="{{actor.uuid}}"
+                    data-spell-id="{{spell.id}}"
+                    data-power-level="{{powerLevel}}"
+                    data-wp-cost="{{wpCost}}"
+                    {{#if isMagicCrit }} data-is-magic-crit="{{isMagicCrit}}" {{/if}}
+                    {{#if targetActor }} data-target-id="{{targetActor.uuid}}" {{/if}}
+                    >
+                    <i class="fas fa-dice"></i>
+                    {{localize "DoD.ui.chat.applyConditions"}} {{localize (concat "DoD.conditions." condition)}}
+                </button>
+            {{/if}} <!-- applyConditions -->
         {{/if}} <!-- isCritical -->
     {{/if}} <!-- spell -->
 {{else}} <!-- success -->

--- a/templates/partials/skill-roll-message.hbs
+++ b/templates/partials/skill-roll-message.hbs
@@ -47,40 +47,27 @@
                     >
                     <i class="fas fa-dice"></i>
                     {{#if isHealing}}                
-                    {{localize "DoD.ui.chat.rollHealing"}}
+                        {{localize "DoD.ui.chat.rollHealing"}}
                     {{else}}
-                    {{localize "DoD.ui.chat.rollDamage"}}
+                        {{#if (and isDamaging (not isDamagingWP))}}
+                            {{localize "DoD.ui.chat.rollDamage"}}
+                        {{else}}
+                            {{#if (and isDamagingWP (not isDamaging))}}
+                                {{localize "DoD.ui.chat.rollDamageWP"}}
+                            {{else}}
+                                {{#if applyConditions}}
+                                    {{#if (or isDamagingWP isDamaging)}}
+                                        {{localize "DoD.ui.chat.rollDamageAndApplyConditions"}}
+                                    {{else}}                                                           
+                                        {{localize "DoD.ui.chat.applyConditions"}}
+                                        {{localize (concat "DoD.conditions." condition)}}
+                                    {{/if}}
+                                {{/if}}
+                            {{/if}}    
+                        {{/if}}
                     {{/if}}
                 </button>
             {{/if}} <!-- isDamaging -->
-            {{#if isDamagingWP}}
-                <button class="chat-button magic-roll"
-                    data-action="rollSpellDamageWP"
-                    data-actor-id="{{actor.uuid}}"
-                    data-spell-id="{{spell.id}}"
-                    data-power-level="{{powerLevel}}"   
-                    data-wp-cost="{{wpCost}}"
-                    {{#if isMagicCrit }} data-is-magic-crit="{{isMagicCrit}}" {{/if}}
-                    {{#if targetActor }} data-target-id="{{targetActor.uuid}}" {{/if}}
-                    >
-                    <i class="fas fa-dice"></i>
-                    {{localize "DoD.ui.chat.rollDamageWP"}}
-                </button>
-            {{/if}} <!-- isDamagingWP -->
-            {{#if applyConditions}}
-                <button class="chat-button magic-roll"
-                    data-action="applySpellConditions"
-                    data-actor-id="{{actor.uuid}}"
-                    data-spell-id="{{spell.id}}"
-                    data-power-level="{{powerLevel}}"
-                    data-wp-cost="{{wpCost}}"
-                    {{#if isMagicCrit }} data-is-magic-crit="{{isMagicCrit}}" {{/if}}
-                    {{#if targetActor }} data-target-id="{{targetActor.uuid}}" {{/if}}
-                    >
-                    <i class="fas fa-dice"></i>
-                    {{localize "DoD.ui.chat.applyConditions"}} {{localize (concat "DoD.conditions." condition)}}
-                </button>
-            {{/if}} <!-- applyConditions -->
         {{/if}} <!-- isCritical -->
     {{/if}} <!-- spell -->
 {{else}} <!-- success -->

--- a/templates/parts/item-sheet-spell.hbs
+++ b/templates/parts/item-sheet-spell.hbs
@@ -66,16 +66,41 @@
         <table class="simple-table">
             <tr>
                 <th>{{localize "DoD.spell.damage"}}</th>
+                <th>{{localize "DoD.spell.damageType"}}</th>
                 <th>{{localize "DoD.spell.damagePerPowerlevel"}}</th>
             </tr>
             
             <tr>
                 <td>
                     <input name="system.damage" type="text" value="{{system.damage}}" pattern="{{spellDamagePattern}}"/>
+                </td>
+                <td>  
+                    {{formInput
+                        systemFields.damageType
+                        value=system.damageType
+                        localize=true
+                    }}
                 </td>    
                 <td>
                     <input name="system.damagePerPowerlevel" type="text" value="{{system.damagePerPowerlevel}}" pattern="{{dicePattern}}"/>
                 </td>    
+            </tr>
+            <tr>               
+                <th colspan="2">{{localize "DoD.spell.damagewP"}}</th>
+         
+                <th>{{localize "DoD.spell.applyCondition"}}</th>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <input name="system.damageWP" type="text" value="{{system.damageWP}}" pattern="{{spellDamagePattern}}"/>
+                </td>
+                <td>
+                    {{formInput
+                        systemFields.applyConditions
+                        value=system.applyConditions
+                        localize=true
+                    }}
+                </td>
             </tr>
         </table>
     </div>


### PR DESCRIPTION
I add option for spell to deal damage to WP and apply Condition ( only one)
In spell sheet in details are new option for WP damage and Condition,
WP damage follow the same logic like normal damage.

I add whole logic for dealing damage from chat and heal from chat. 

adres https://github.com/pafvel/dragonbane/issues/221 and https://github.com/pafvel/dragonbane/issues/222